### PR TITLE
Add country / region / city to identify calls

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -96,11 +96,15 @@ class AmplitudeAPI
 
     # ==== Identification related methods
 
-    def send_identify(user_id, device_id, user_properties = {})
+    def send_identify(user_id:, device_id:, user_properties: {}, country: nil, region: nil, city: nil, dma: nil)
       identification = AmplitudeAPI::Identification.new(
         user_id: user_id,
         device_id: device_id,
-        user_properties: user_properties
+        user_properties: user_properties,
+        country: country,
+        region: region,
+        city: city,
+        dma: dma
       )
       identify(identification)
     end

--- a/lib/amplitude_api/identification.rb
+++ b/lib/amplitude_api/identification.rb
@@ -12,16 +12,32 @@ class AmplitudeAPI
     # @!attribute [ rw ] user_properties
     #   @return [ String ] the user_properties to be attached to the Amplitude Identify
     attr_accessor :user_properties
+    # @!attribute [ rw ] country
+    #   @return [ String ] the country to be sent to the Amplitude Identify
+    attr_accessor :country
+    # @!attribute [ rw ] region
+    #   @return [ String ] the region to be sent to the Amplitude Identify
+    attr_accessor :region
+    # @!attribute [ rw ] city
+    #   @return [ String ] the city to be sent to the Amplitude Identify
+    attr_accessor :city
+    # @!attribute [ rw ] dma
+    #   @return [ String ] the dma to be sent to the Amplitude Identify
+    attr_writer :dma
 
     # Create a new Identification
     #
     # @param [ String ] user_id a user_id to associate with the identification
     # @param [ String ] device_id a device_id to associate with the identification
     # @param [ Hash ] user_properties various properties to attach to the user identification
-    def initialize(user_id: "", device_id: nil, user_properties: {})
+    def initialize(user_id: "", device_id: nil, user_properties: {}, country: nil, region: nil, city: nil, dma: nil)
       self.user_id = user_id
       self.device_id = device_id if device_id
       self.user_properties = user_properties
+      self.country = country
+      self.region = region
+      self.city = city
+      self.dma = dma
     end
 
     def user_id=(value)
@@ -39,7 +55,11 @@ class AmplitudeAPI
     def to_hash
       {
         user_id: user_id,
-        user_properties: user_properties
+        user_properties: user_properties,
+        country: country,
+        region: region,
+        city: city,
+        dma: dma
       }.tap { |hsh| hsh[:device_id] = device_id if device_id }
     end
 
@@ -53,5 +73,17 @@ class AmplitudeAPI
         false
       end
     end
+
+    private
+
+    # I don't really know what DMA is, but I don't think we need it. However if we don't send a value, it resets the others. So if we have country, region and city but no DMA let's send them an empty string
+    def dma
+      if @dma == nil && country && region && city
+        ''
+      else
+        @dma
+      end
+    end
+
   end
 end

--- a/lib/amplitude_api/version.rb
+++ b/lib/amplitude_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AmplitudeAPI
-  VERSION = "0.4.2"
+  VERSION = "0.5.0"
 end

--- a/spec/lib/amplitude_api/identification_spec.rb
+++ b/spec/lib/amplitude_api/identification_spec.rb
@@ -3,55 +3,72 @@
 require "spec_helper"
 
 describe AmplitudeAPI::Identification do
-  user = Struct.new(:id)
+  subject(:identification) { described_class.new(**identification_params) }
+  let(:user) {  Struct.new(:id) }
 
   context "with a user object" do
+    let(:identification_params) {  { user_id: user.new(123) } }
+
     describe "#body" do
       it "populates with the user's id" do
-        identification = described_class.new(user_id: user.new(123))
         expect(identification.to_hash[:user_id]).to eq(123)
       end
     end
   end
 
   context "with a user id" do
+    let(:identification_params) {  { user_id: 123 } }
+
     describe "#body" do
       it "populates with the user's id" do
-        identification = described_class.new(user_id: 123)
         expect(identification.to_hash[:user_id]).to eq(123)
+      end
+
+      it "includes the device id" do
+        identification = described_class.new(user_id: 123, device_id: "abc")
+        expect(identification.to_hash[:device_id]).to eq("abc")
+      end
+
+      it "includes arbitrary user properties" do
+        identification = described_class.new(
+          user_id: 123,
+          user_properties: {
+            first_name: "John",
+            last_name: "Doe"
+          }
+        )
+        expect(identification.to_hash[:user_properties]).to eq(first_name: "John", last_name: "Doe")
+      end
+
+      context "with country data" do
+        let(:identification_params) { { user_id: 123, country: 'GB', region: 'Sussex', city: 'Lewes', dma: nil } }
+
+        it "includes country data" do
+          expect(identification.to_hash[:country]).to eq('GB')
+        end
+
+        it "includes region data" do
+          expect(identification.to_hash[:region]).to eq('Sussex')
+        end
+
+        it "includes city data" do
+          expect(identification.to_hash[:city]).to eq('Lewes')
+        end
+
+        it "includes dma data" do
+          expect(identification.to_hash[:dma]).to eq('')
+        end
       end
     end
   end
 
   context "without a user" do
+    let(:identification_params) {  { user_id: nil } }
+
     describe "#body" do
       it "populates with the unknown user" do
-        identification = described_class.new(user_id: nil)
         expect(identification.to_hash[:user_id]).to eq(AmplitudeAPI::USER_WITH_NO_ACCOUNT)
       end
-    end
-  end
-
-  describe "#body" do
-    it "includes the user id" do
-      identification = described_class.new(user_id: 123)
-      expect(identification.to_hash[:user_id]).to eq(123)
-    end
-
-    it "includes the device id" do
-      identification = described_class.new(user_id: 123, device_id: "abc")
-      expect(identification.to_hash[:device_id]).to eq("abc")
-    end
-
-    it "includes arbitrary user properties" do
-      identification = described_class.new(
-        user_id: 123,
-        user_properties: {
-          first_name: "John",
-          last_name: "Doe"
-        }
-      )
-      expect(identification.to_hash[:user_properties]).to eq(first_name: "John", last_name: "Doe")
     end
   end
 end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -166,7 +166,10 @@ describe AmplitudeAPI do
             user_properties: {
               first_name: "John",
               last_name: "Doe"
-            }
+            },
+            country: 'GB',
+            region: 'Sussex',
+            city: 'Lewes',
           )
           body = {
             api_key: described_class.api_key,
@@ -350,64 +353,91 @@ describe AmplitudeAPI do
   end
 
   describe ".send_identify" do
+    before do
+      allow(described_class).to receive(:identify)
+      described_class.send_identify(user_id: user, device_id: device_id, user_properties: { first_name: "John", last_name: "Doe" }, country: 'GB', region: 'Sussex', city: 'Lewes')
+    end
+
     context "with no device_id" do
-      it "sends an identify to AmplitudeAPI" do
-        identification = AmplitudeAPI::Identification.new(
+      let(:device_id) { nil }
+      let(:identification) do
+        AmplitudeAPI::Identification.new(
           user_id: user,
           user_properties: {
             first_name: "John",
             last_name: "Doe"
-          }
+          },
+          country: 'GB',
+          region: 'Sussex',
+          city: 'Lewes',
         )
-        expect(described_class).to receive(:identify).with(identification)
+      end
 
-        described_class.send_identify(user, nil, first_name: "John", last_name: "Doe")
+      it "sends an identify to AmplitudeAPI" do
+        expect(described_class).to have_received(:identify).with(identification)
       end
 
       context "the user is nil" do
-        it "sends an identify with the no account user" do
-          identification = AmplitudeAPI::Identification.new(
-            user_id: nil,
+        let(:identification) do
+          AmplitudeAPI::Identification.new(
+            user_id: AmplitudeAPI::USER_WITH_NO_ACCOUNT,
             user_properties: {
               first_name: "John",
               last_name: "Doe"
-            }
+            },
+            country: 'GB',
+            region: 'Sussex',
+            city: 'Lewes',
           )
-          expect(described_class).to receive(:identify).with(identification)
+        end
 
-          described_class.send_identify(nil, nil, first_name: "John", last_name: "Doe")
+        let(:user) { nil }
+
+        it "sends an identify with the no account user" do
+          expect(described_class).to have_received(:identify).with(identification)
         end
       end
 
       context "the user is a user_id" do
-        it "sends an identify to AmplitudeAPI" do
-          identification = AmplitudeAPI::Identification.new(
+        let(:identification) do
+          AmplitudeAPI::Identification.new(
             user_id: 123,
             user_properties: {
               first_name: "John",
               last_name: "Doe"
-            }
+            },
+            country: 'GB',
+            region: 'Sussex',
+            city: 'Lewes',
           )
-          expect(described_class).to receive(:identify).with(identification)
+        end
 
-          described_class.send_identify(user.id, nil, first_name: "John", last_name: "Doe")
+        it "sends an identify to AmplitudeAPI" do
+          expect(described_class).to have_received(:identify).with(identification)
         end
       end
     end
 
     context "with a device_id" do
-      it "sends an identify to AmplitudeAPI" do
+      let(:identification) do
         identification = AmplitudeAPI::Identification.new(
           user_id: user,
           device_id: "abc",
           user_properties: {
             first_name: "John",
             last_name: "Doe"
-          }
-        )
-        expect(described_class).to receive(:identify).with(identification)
+          },
+          country: 'GB',
+          region: 'Sussex',
+          city: 'Lewes',
 
-        described_class.send_identify(user, "abc", first_name: "John", last_name: "Doe")
+
+        )
+      end
+      let(:device_id) { "abc" }
+
+      it "sends an identify to AmplitudeAPI" do
+        expect(described_class).to have_received(:identify).with(identification)
       end
     end
   end


### PR DESCRIPTION
We want to be able to send country, region, city and dma to Identify calls so we can update the Country field... but sending them as part of `user_properties` just creates another field! So we need to update the Gem to send these fields